### PR TITLE
add link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-authy
 ==========
 
-Authy API Client for node.js
+[Authy](https://authy.com/) API Client for node.js
 
 Usage
 =====


### PR DESCRIPTION
I had to type authy.com because it was only in the description. This is not ideal.

I think the API docs should link to the home page too. How about adding it to the markdown comment in the JavaScript and regenerating it with Docco?

BTW that's an ambitious project you got there. Best of luck!
