### PR TITLE
Consistently parses Authy API response body as JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,13 @@ Authy.prototype.register_user = function (email, cellphone, country_code, callba
         qs: {
             api_key: this.apiKey
         },
+        json: true,
         jar: false,
         strictSSL: true
     }, function (err, res, body) {
         if (!err) {
             if(res.statusCode === 200) {
-                callback(null, JSON.parse(body));
+                callback(null, body);
             } else {
                 callback(body);
             }
@@ -48,6 +49,7 @@ Authy.prototype.delete_user = function (id, callback) {
         qs: {
             api_key: this.apiKey
         },
+        json: true,
         jar: false,
         strictSSL: true
     }, function (err, res, body) {
@@ -77,14 +79,15 @@ Authy.prototype.verify = function (id, token, force, callback) {
     request.get({
         url: this.apiURL + "/protected/json/verify/" + token + "/" + id,
         qs: qs,
+        json: true,
         jar: false,
         strictSSL: true
     }, function (err, res, body) {
         if (!err) {
             if (res.statusCode === 200) {
-                callback(null, toJSON(body));
+                callback(null, body);
             } else {
-                callback(toJSON(body));
+                callback(body);
             }
         } else {
             callback(err);
@@ -106,12 +109,13 @@ Authy.prototype.request_sms = function (id, force, callback) {
     request.get({
         url: this.apiURL + "/protected/json/sms/" + id,
         qs: qs,
+        json: true,
         jar: false,
         strictSSL: true
     }, function (err, res, body) {
         if (!err) {
             if (res.statusCode === 200) {
-                callback(null, toJSON(body));
+                callback(null, body);
             } else {
                 callback(body);
             }
@@ -135,12 +139,13 @@ Authy.prototype.request_call = function (id, force, callback) {
     request.get({
         url: this.apiURL + "/protected/json/call/" + id,
         qs: qs,
+        json: true,
         jar: false,
         strictSSL: true
     }, function (err, res, body) {
         if (!err) {
             if (res.statusCode === 200) {
-                callback(null, toJSON(body));
+                callback(null, body);
             } else {
                 callback(body);
             }
@@ -149,24 +154,3 @@ Authy.prototype.request_call = function (id, force, callback) {
         }
     });
 };
-
-// Utility functions. Should live somewhere else probably.
-function isJSON(data) {
-    if (typeof data === 'object') return true;
-    try {
-        data = JSON.parse(data);
-        return true;
-    } catch (e) {
-        return false;
-    }
-}
-
-function toJSON(data) {
-    if (typeof data === 'object') return data;
-    try {
-        data = JSON.parse(data);
-        return data;
-    } catch (e) {
-        return data;
-    }
-}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4,11 +4,19 @@ var authy = require('../index')(apikey,'http://sandbox-api.authy.com');
 var test_user = {email: 'baldwin@andyet.net', phone: '825-589-8570', country: '5'};
 
 /*
+ * Nodeunit swallows uncaught exceptions--get them back!
+ */
+process.on('uncaughtException', function(err) {
+    console.error(err.stack);
+});
+
+/*
  *  Register New User Tests
  */
 exports['Register New User - Without country code'] = function (test) {
     authy.register_user(test_user.email, test_user.phone, function (err, res) {
         test.ok(res);
+        test.equal(typeof(res), 'object', 'Response should be an object.');
         test.ok(res.user);
         test_user.id = res.user.id; // Save ID for future tests
         test.done();
@@ -18,12 +26,36 @@ exports['Register New User - Without country code'] = function (test) {
 exports['Register New User - With country code'] = function (test) {
     authy.register_user(test_user.email, test_user.phone, test_user.country, function (err, res) {
         test.ok(res);
+        test.equal(typeof(res), 'object', 'Response should be an object.');
         test.done();
     });
 };
 
 exports['Register New User - Blank Email'] = function (test) {
-    test.done();
+    authy.register_user(null, test_user.phone, test_user.country, function (err, res) {
+        test.ok(err, 'Should get error.');
+        test.equal(typeof(err), 'object', 'Error should be an object.');
+        test.equal(err.success, false, 'Success should be false.')
+        test.done();
+    });
+};
+
+exports['Register New User - Blank Phone'] = function (test) {
+    authy.register_user(test_user.email, null, test_user.country, function (err, res) {
+        test.ok(err, 'Should get error.');
+        test.equal(typeof(err), 'object', 'Error should be an object.');
+        test.equal(err.success, false, 'Success should be false.')
+        test.done();
+    });
+};
+
+exports['Register New User - Invalid Country Code'] = function (test) {
+    authy.register_user(test_user.email, null, -100, function (err, res) {
+        test.ok(err, 'Should get error.');
+        test.equal(typeof(err), 'object', 'Error should be an object.');
+        test.equal(err.success, false, 'Success should be false.')
+        test.done();
+    });
 };
 
 /*
@@ -32,6 +64,7 @@ exports['Register New User - Blank Email'] = function (test) {
 exports['Verify Token'] = function (test) {
     authy.verify(test_user.id, '0000000', function (err, res) {
         test.ok(res);
+        test.equal(typeof(res), 'object', 'Response should be an object.');
         test.done();
     });
 };
@@ -39,6 +72,7 @@ exports['Verify Token'] = function (test) {
 exports['Verify Token - Force'] = function (test) {
     authy.verify(test_user.id, '0000000', true, function (err, res) {
         test.ok(res);
+        test.equal(typeof(res), 'object', 'Response should be an object.');
         test.done();
     });
 };


### PR DESCRIPTION
Uses request library's JSON option instead of toJSON function and does so for all APIs.
