### PR TITLE
Remove the reference to call support@authy.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ authy.request_sms('1337', function (err, res) {
 });
 ```
 
-#### Request Call (Email support@authy.com to enable this feature)
+#### Request Call 
 
 request_call(id, [force], callback);
 


### PR DESCRIPTION
There was a reference to contact our support to enable a feature. This is no longer true.