### PR TITLE
extended options objects directly from params fixes #23

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,10 +118,10 @@ Authy.prototype.phones = function() {
             options = {
                 phone_number: phone_number,
                 country_code: country_code,
-                via: params.via || "sms",
-                locale: params.locale,
-                custom_message: params.custom_message
+                via: params.via || "sms"
             };
+
+            options = Object.assign(options, params);
 
             self._request("post", "/protected/json/phones/verification/start", options, callback);
         },


### PR DESCRIPTION
I've left the initalization with the required params so we can simply extend the object with the incoming ones.
Authy's API does not take into account not recognized parameters.
So this pretty much fixes #23