### PR TITLE
Move documentation to twilio.com/docs/authy/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,166 +1,72 @@
-# node-authy [![Dependency Status](https://david-dm.org/evilpacket/node-authy.png)](https://david-dm.org/evilpacket/node-authy)
+[![Dependency Status](https://david-dm.org/evilpacket/node-authy.png)](https://david-dm.org/evilpacket/node-authy)
 
-[Authy](https://www.twilio.com/authy) and [Verify](https://www.twilio.com/verify) API Client for Node.js written by Adam Baldwin.
+# Node.js Client for Twilio Authy Two-Factor Authentication (2FA) API
 
-## Installation
+[Authy](https://www.twilio.com/authy) client for Node.js written by Adam Baldwin.
 
-```
-npm install authy
-```
+Documentation for this Node.js usage of the Authy API lives in the [official Twilio documentation](https://www.twilio.com/docs/authy/api/).
 
-When in doubt check out the official [Authy](https://www.twilio.com/docs/authy) and [Verify](https://www.twilio.com/docs/verify) docs.
+The Authy API supports multiple channels of 2FA:
+* One-time passwords via SMS and voice.
+* Soft token ([TOTP](https://www.twilio.com/docs/glossary/totp) via the Authy App)
+* Push authentication via the Authy App
+
+If you only need SMS and Voice support for one-time passwords, we recommend using the [Twilio Verify API](https://www.twilio.com/docs/verify/api) instead. 
+
+[More on how to choose between Authy and Verify here.](https://www.twilio.com/docs/verify/authy-vs-verify)
+
+### Authy Quickstart
+
+For a full tutorial, check out the Node.js Authy Quickstart in our docs:
+* [Node.js Authy Quickstart](https://www.twilio.com/docs/authy/quickstart/two-factor-authentication-nodejs)
+
+## Authy Node.js Installation
+
+Install with [npm](https://www.npmjs.com/):
+
+    $ npm install authy
 
 ## Usage
 
-#### Requiring node-authy
+To use the Authy client, require `Authy` and initialize it with your production API Key found in the [Twilio Console](https://www.twilio.com/console/authy/applications/):
 
-```javascript
+```js
 var authy = require('authy')('APIKEY');
 ```
 
-#### Send OneTouch
-[OneTouch API docs](https://www.twilio.com/docs/authy/api/push-authentications) are the source of truth.
-send_approval_request(id,user_payload,hidden_details,logos,callback)
-```javascript
-authy.send_approval_request('1337', user_payload, [hidden_details], [logos], function (err, res) {
-    // res = {"approval_request":{"uuid":"########-####-####-####-############"},"success":true}
-});
-```
+![authy api key in console](https://s3.amazonaws.com/com.twilio.prod.twilio-docs/images/account-security-api-key.width-800.png)
 
-* id is the Authy id.
-* user_payload:  { 'message': 'user message here', ['details': {...}] }
-* hidden_details: optional
-* logos: optional 
+## 2FA Workflow
 
-#### Check Approval Status
+1. [Create a user](https://www.twilio.com/docs/authy/api/users#enabling-new-user)
+2. [Send a one-time password](https://www.twilio.com/docs/authy/api/one-time-passwords)
+3. [Verify a one-time password](https://www.twilio.com/docs/authy/api/one-time-passwords#verify-a-one-time-password)
 
-check_approval_status (uuid,callback)
-```javascript
-authy.check_approval_status(uuid, function(err, res) {
-    res = {
-      "approval_request": {
-        "_app_name": YOUR_APP_NAME,
-        "_app_serial_id": APP_SERIAL_ID,
-        "_authy_id": AUTHY_ID,
-        "_id": INTERNAL_ID,
-        "_user_email": EMAIL_ID,
-        "app_id": APP_ID,
-        "created_at": TIME_STAMP,
-        "notified": false,
-        "processed_at": null,
-        "seconds_to_expire": 600,
-        "status": 'pending',
-        "updated_at": TIME_STAMP,
-        "user_id": USER_ID,
-        "uuid": UUID
-      },
-      "success": true
-    }
-});
-```
-#### Register New User
-[User API Information](https://www.twilio.com/docs/authy/api/users)
+**OR**
 
-register_user(email, cellphone, [country_code], [send_install_link_via_sms], callback);
+1. [Create a user](https://www.twilio.com/docs/authy/api/users#enabling-new-user)
+2. [Send a push authentication](https://www.twilio.com/docs/authy/api/push-authentications)
+3. [Check a push authentication status](https://www.twilio.com/docs/authy/api/push-authentications#check-approval-request-status)
 
 
-```javascript
-authy.register_user('baldwin@andyet.net', '509-555-1212', function (err, res) {
-    // res = {user: {id: 1337}} where 1337 = ID given to use, store this someplace
-});
-```
+## <a name="phone-verification"></a>Phone Verification
 
-If not given, `country_code` defaults to `"1"` and `send_install_link_via_sms` defaults to `true`.
+[Phone verification now lives in the Twilio API](https://www.twilio.com/docs/verify/api) and has [Node.js support through the official Twilio helper libraries](https://www.twilio.com/docs/libraries/node). 
 
-#### Verify Token
+[Legacy (V1) documentation here.](verify-legacy-v1.md) **Verify V1 is not recommended for new development. Please consider using [Verify V2](https://www.twilio.com/docs/verify/api)**.
 
-verify(id, token, [force], callback);
+## Contributing
 
-```javascript
-authy.verify('1337', '0000000', function (err, res) {
+Install dependencies:
 
-});
-```
+    npm install
 
-#### Request SMS
+To run tests:
 
-request_sms(id, [force], callback);
-
-```javascript
-authy.request_sms('1337', function (err, res) {
-
-});
-```
-
-=======
+    npm test
 
 
-request_call(id, [force], callback);
-
-```javascript
-authy.request_call('1337', function (err, res) {
-
-});
-```
-
-#### Delete Registered User
-
-delete_user(id, callback);
-
-```javascript
-authy.delete_user('1337', function (err, res) {
-
-});
-```
-
-#### Get Registered User Status
-
-user_status(id, callback);
-
-```javascript
-authy.user_status('1337', function (err, res) {
-
-});
-```
-
-#### Start Phone Verification
-Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
-
-phones().verification_start(phone_number, country_code, params, callback);
-
-```javascript
-authy.phones().verification_start('111-111-1111', '1', { via: 'sms', locale: 'en', code_length: '6' }, function(err, res) {
-
-});
-```
-
-The `params` argument is optional and sets 'sms' as the default `via`, leaving the other two options blank.
-
-
-#### Check Phone Verification
-Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
-
-phones().verification_check(phone_number, country_code, verification_code, callback);
-
-```javascript
-authy.phones().verification_check('111-111-1111', '1', '0000', function (err, res) {
-
-});
-```
-
-#### Status of Phone Verification
-Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
-
-phones().verification_status(phone_number, country_code, callback);
-
-```javascript
-authy.phones().verification_status('111-111-1111', '1', function (err, res) {
-
-});
-```
-
-
-##### Contributors
+### Contributors
 
 - [Daniel Barnes](https://github.com/DanielBarnes)
 - [Josh Staples](https://github.com/josh-authy)

--- a/verify-legacy-v1.md
+++ b/verify-legacy-v1.md
@@ -1,0 +1,49 @@
+# Phone Verification V1
+
+[Version 2 of the Verify API is now available!](https://www.twilio.com/docs/verify/api) V2 has an improved developer experience and new features. Some of the features of the V2 API include:
+
+* Twilio helper libraries in JavaScript, Java, C#, Python, Ruby, and PHP
+* PSD2 Secure Customer Authentication Support
+* Improved Visibility and Insights
+
+You are currently viewing Version 1. V1 of the API will be maintained for the time being, but any new features and development will be on Version 2. We strongly encourage you to do any new development with API V2. Check out the migration guide or the API Reference for more information.
+
+### API Reference
+
+API Reference is available at https://www.twilio.com/docs/verify/api/v1
+
+#### Start Phone Verification
+Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
+
+phones().verification_start(phone_number, country_code, params, callback);
+
+```javascript
+authy.phones().verification_start('111-111-1111', '1', { via: 'sms', locale: 'en', code_length: '6' }, function(err, res) {
+
+});
+```
+
+The `params` argument is optional and sets 'sms' as the default `via`, leaving the other two options blank.
+
+
+#### Check Phone Verification
+Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
+
+phones().verification_check(phone_number, country_code, verification_code, callback);
+
+```javascript
+authy.phones().verification_check('111-111-1111', '1', '0000', function (err, res) {
+
+});
+```
+
+#### Status of Phone Verification
+Browse the [API docs](https://www.twilio.com/docs/verify/api/verification) for all available params.
+
+phones().verification_status(phone_number, country_code, callback);
+
+```javascript
+authy.phones().verification_status('111-111-1111', '1', function (err, res) {
+
+});
+```


### PR DESCRIPTION
I moved all of the documentation to the Twilio docs so we have more standardized quality and coverage in one place. You can find all of the Node samples there:

https://www.twilio.com/docs/authy/api/applications
https://www.twilio.com/docs/authy/api/users
https://www.twilio.com/docs/authy/api/one-time-passwords
https://www.twilio.com/docs/authy/api/push-authentications

This PR updates the README to point folks to those links for the source of truth.

Also moved Phone Verification docs to a separate page to encourage folks to use V2. You can see these changes also in the [Python](https://github.com/twilio/authy-python) and [PHP](https://github.com/twilio/authy-php) libraries